### PR TITLE
Update README to include `lib-address`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Only two dependencies:
 
 * [`ethereumjs-util`](https://github.com/ethereumjs/ethereumjs-util)
 * [`lib-blockies`](https://github.com/eth-button/lib-blockies)
+* [`lib-address`](https://github.com/eth-button/lib-address)
 
 ## Usage
 


### PR DESCRIPTION
Fixes #1 

Adds a link to `lib-address` in the readme.